### PR TITLE
Fix author in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ QtVerbalExpressions
 
 ## Qt Regular Expressions made easy
 
-This Qt lib is based off of the C++ [VerbalExpressions](https://github.com/VerbalExpressions/CppVerbalExpressions) library by [ionutvmi](https://github.com/ionutvmi).
+This Qt lib is based off of the C++ [VerbalExpressions](https://github.com/VerbalExpressions/CppVerbalExpressions) library by [whackashoe](https://github.com/whackashoe).
 
 ### Testing if we have a valid URL
 


### PR DESCRIPTION
Hi!

I actually wrote CppVerbalExpressions, not ionutvmi. He just created the repo as I don't have repo creation ability (only collaborator in verbalexpressions group). You can verify this in the git history. Feel somewhat odd making this pull request, but figured it _technically_ is a documentation bug hehe. 

Thanks for making good use of it! 
